### PR TITLE
fix: listen for member_joined_channel

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -223,7 +223,7 @@ func (r *Relay) Reply(subtype, target, text string) {
 	switch subtype {
 	case "me_message":
 		r.ircb.Connection.Action(target, text)
-	case "channel_join":
+	case "member_joined_channel":
 		r.ircb.Connection.Notice(target, text)
 	default:
 		r.ircb.Connection.Privmsg(target, text)


### PR DESCRIPTION
Dersom nyeste verjson kjører i #bitraf @ Freenode nå, så fungerte det ikke. Dette er en mulig fix. Kanskje det samsvarer med loggene dine?

--

API has probably changed since the writing of the examples in
nlopes/slack:
https://github.com/nlopes/slack/blob/master/examples/eventsapi/events.go

Looking up the offical API, seems it's now called
`member_joined_channel` instead of `channel_join`.
https://api.slack.com/events/member_joined_channel